### PR TITLE
[Refactor] [Done] [Parth] Refactored the userOrchestration to support flexible registration of new roles

### DIFF
--- a/langsuit/app/api/auth/signup/route.ts
+++ b/langsuit/app/api/auth/signup/route.ts
@@ -1,13 +1,10 @@
-
-import db from "@/db/drizzle";
-import { user } from "@/db/schema";
-import { User } from "@/utils/dbOrchestrator";
+import { UserOrchestrator } from "@/utils/dbOrchestrator";
 
 export const POST = async (req: Request,res: Response) => {
     try{
         const body = await req.json();
         const { username,email,password,role } = body;
-        await User.instance.insert(role,username,email,password);
+        await UserOrchestrator.get(role).insert(role,username,email,password);
         return Response.json({message: "User created successfully"},{status: 200});
     }catch(err){
         console.error(err);

--- a/langsuit/utils/dbOrchestrator.ts
+++ b/langsuit/utils/dbOrchestrator.ts
@@ -22,8 +22,8 @@ export class UserOrchestrator {
     private m_RegisteredUser:Map<String,any> = new Map();
     static #instance: UserOrchestrator;
     
-    public registerUser(productID:String, user:User){
-        this.m_RegisteredUser.set(productID, user);
+    public registerUser(userID:String, user:User){
+        this.m_RegisteredUser.set(userID, user);
     }
     
     public static get instance(): UserOrchestrator {


### PR DESCRIPTION
This commit aims to improve the code quality of #4.
 
The previous method uses a naive switch casing to make sure the targeted role, which makes in less flexible and prone to errors in further addition of new roles. 
The current code contains a static block to automatic register itself in the orchestration, which means new role just needs a new class instead of any other code changes.

Proposed future roles : 
Stream Organizer : Moderator kind of during the streaming.
Community Based Groups :  Group Owner 
                                                   Group mods
  